### PR TITLE
[Docker version]: Use newer version of alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.3-alpine-3.14
+FROM mcr.microsoft.com/powershell:7.3-alpine-3.17
 
 # install packages required to run the tests
 RUN apk add --no-cache jq coreutils


### PR DESCRIPTION
This makes so the test runner is a bit lighter (around 20 mb) and uses a more modern underlying os